### PR TITLE
Revert "Drop dash limitation"

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -121,7 +121,7 @@ class Tag < ActsAsTaggableOn::Tag
     # [:alnum:] is not used here because it supports diacritical characters.
     # If we decide to allow diacritics in the future, we should replace the
     # following regex with [:alnum:].
-    errors.add(:name, I18n.t("errors.messages.contains_prohibited_characters")) unless name.match?(/\A[[:alnum:]-]+\z/i)
+    errors.add(:name, I18n.t("errors.messages.contains_prohibited_characters")) unless name.match?(/\A[[:alnum:]]+\z/i)
   end
 
   # While this non-end user facing flag is "in play", our goal is to say that when it's "false"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Tag, type: :model do
       it { is_expected.to validate_length_of(:name).is_at_most(30) }
       it { is_expected.to validate_presence_of(:category) }
 
-      it { is_expected.not_to allow_value("#Hello", "c++", "AWS_Lambda").for(:name) }
+      it { is_expected.not_to allow_value("#Hello", "c++", "AWS-Lambda").for(:name) }
 
       # rubocop:disable RSpec/NamedSubject
       it do
@@ -87,10 +87,6 @@ RSpec.describe Tag, type: :model do
         # ™ is not :alnum:
         tag.name = "Test™"
         expect(tag).not_to be_valid
-
-        # - is valid
-        tag.name = "tag-with-dash"
-        expect(tag).to be_valid
       end
     end
 


### PR DESCRIPTION
Reverts codeclimate/forem#3 Turns out we can just have a `Pretty Name` set for the tags so that even if we dont have hypens, things look presentable to customers:

<img width="1727" alt="Screen Shot 2022-11-09 at 10 50 06 AM" src="https://user-images.githubusercontent.com/5769282/200876708-851052e0-b1c9-4d61-b2ad-cbd268f2fd8d.png">
